### PR TITLE
feat : mongoAuditing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### oauth ###
+
+application-auth.properties

--- a/src/main/java/com/triples/project/configuration/chromeDriver/ChromeDriverContext.java
+++ b/src/main/java/com/triples/project/configuration/chromeDriver/ChromeDriverContext.java
@@ -42,7 +42,7 @@ public class ChromeDriverContext {
         WebDriverManager.chromedriver().setup();
 
         ChromeOptions options = new ChromeOptions();
-       // options.addArguments("headless");
+        options.addArguments("headless");
         driver = new ChromeDriver(options);
         driver.manage().window().maximize(); // window 창 최대화
 

--- a/src/main/java/com/triples/project/dao/collection/Card.java
+++ b/src/main/java/com/triples/project/dao/collection/Card.java
@@ -2,8 +2,15 @@ package com.triples.project.dao.collection;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
 
 @Getter
 @Document
@@ -21,10 +28,16 @@ public class Card {
     private String category;
     private String date;        //
     private String saved_count; // 좋아요 수
+    @CreatedDate
     private String created_at;  // 크롤링한 날짜
+    @LastModifiedDate
+    private String updated_at; // update 날짜
 
     @Builder
-    public Card(String image, String writer, String link, String title, String description, String platform, Boolean is_saved, String category, String date, String saved_count, String created_at) {
+    public Card(String image, String writer, String link, String title,
+                String description, String platform, Boolean is_saved,
+                String category, String date, String saved_count, String created_at,
+                String updated_at) {
         this.image = image;
         this.writer = writer;
         this.link = link;
@@ -36,5 +49,6 @@ public class Card {
         this.date = date;
         this.saved_count = saved_count;
         this.created_at = created_at;
+        this.updated_at = updated_at;
     }
 }


### PR DESCRIPTION
- Card.java Collection에서 카드를 크롤링해서 DB에 추가할 때 created_at (생성날짜)를 수작업으로 넣고 있는데 이를 
자동으로 생성해주는 방법이 있어서 공유 합니다.
아래와 같이 @EnableMongoAuditing 어노테이션을 추가 하여 사용 가능합니다.

> mongoConfig.java

```
@Configuration
@EnableMongoAuditing
public class mongoConfig {
}
```

아래와 같이 생성 날짜와 변경날짜 각각 어노테이션을 추가 후 DB에 insert 혹은 update 해보면 자동으로 날짜를 생성하여 줍니다.
Test 후 문제점이 있으면 코멘트 부탁드립니다.

> Card.java

```
@Getter
@Document
public class Card {

    @Id
    public String id;
    private String image;
    private String writer;
    private String link;
    private String title;
    private String description;
    private String platform;
    private Boolean is_saved;    // 좋아요
    private String category;
    private String date;        //
    private String saved_count; // 좋아요 수
    @CreatedDate
    private String created_at;  // 크롤링한 날짜
    @LastModifiedDate
    private String updated_at; // update 날짜
```