### PR TITLE
fix : previous and next move of cursor based pagination

### DIFF
--- a/src/main/java/com/triples/project/controller/CardApiController.java
+++ b/src/main/java/com/triples/project/controller/CardApiController.java
@@ -5,7 +5,6 @@ import com.triples.project.dto.CursorResult;
 import com.triples.project.service.CardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.types.ObjectId;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,17 +27,17 @@ public class CardApiController {
      * 전체 카드 리스트 불러오기
      */
     @GetMapping("/api/v1/cards")
-    public ResponseEntity<CursorResult<Card>> findAll(@RequestParam(required = false) ObjectId cursorId,
+    public ResponseEntity<CursorResult<Card>> findAll(@RequestParam(required = false) String next,
+                                                      @RequestParam(required = false) String previous,
                                                       @RequestParam(required = false) Integer pageSize) {
 
-//        List<Card> cardList = cardService.findAll();
-
-        log.info("[findAll] cursorId ans pageSize :" + cursorId + ", " + pageSize);
+        log.info("[findAll] previous cursor :" + previous);
+        log.info("[findAll] next cursor :" + next);
 
         if(pageSize == null) pageSize = PAGE_SIZE;
 
         CursorResult<Card> result  =
-                cardService.findAllByOrderByIdDesc(cursorId, PageRequest.of(0, pageSize));
+                cardService.findAllByOrderByIdDesc(previous, next, PageRequest.of(0, pageSize));
 
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/com/triples/project/dao/ICardDao.java
+++ b/src/main/java/com/triples/project/dao/ICardDao.java
@@ -9,13 +9,20 @@ import java.util.List;
 
 public interface ICardDao extends MongoRepository<Card, ObjectId> {
 
+    // first page request
     List<Card> findAllByOrderByIdDesc(Pageable pageable);
 
+    // next cursor pagination after first request
     List<Card> findByIdLessThanOrderByIdDesc(ObjectId id, Pageable pageable);
 
+    // prev cursor pagination after first request
+    List<Card> findByIdGreaterThanOrderByIdAsc(ObjectId id, Pageable pageable);
+
+    // whether next cursor exists
     Boolean existsByIdLessThanOrderByIdDesc(ObjectId id);
 
-    Boolean existsIdBy(ObjectId id);
+    // whether prev cursor exists
+    Boolean existsByIdGreaterThanOrderByIdDesc(ObjectId id);
 
     List<Card> findByPlatform(String platform);
 

--- a/src/main/java/com/triples/project/dao/collection/Card.java
+++ b/src/main/java/com/triples/project/dao/collection/Card.java
@@ -3,15 +3,10 @@ package com.triples.project.dao.collection;
 import lombok.Builder;
 import lombok.Getter;
 import org.bson.types.ObjectId;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.Date;
 
 @Getter
 @Document

--- a/src/main/java/com/triples/project/dto/Cursor.java
+++ b/src/main/java/com/triples/project/dto/Cursor.java
@@ -1,0 +1,23 @@
+package com.triples.project.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Cursor {
+
+    private String previous;      // previous cursor Id
+    private boolean hasPrevious;  // whether the prev cursor exists
+    private String next;          // next cursor id
+    private boolean hasNext;      // whether the next cursor exists
+
+    @Builder
+    public Cursor(String previous, boolean hasPrevious, String next, boolean hasNext) {
+        this.previous = previous;
+        this.hasPrevious = hasPrevious;
+        this.next = next;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/com/triples/project/dto/CursorResult.java
+++ b/src/main/java/com/triples/project/dto/CursorResult.java
@@ -2,7 +2,6 @@ package com.triples.project.dto;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.bson.types.ObjectId;
 
 import java.util.List;
 
@@ -11,14 +10,10 @@ import java.util.List;
 public class CursorResult<T> {
 
     private List<T> values; // cursor based pagination list
-    private boolean hasNext; // if there is data following the cursor
-    private ObjectId cursorId; // cursor based pagination
-    private int findCardsCount;  // result cards count
+    private Cursor cursors;
 
-    public CursorResult(List<T> values, boolean hasNext, ObjectId cursorId, int findCardsCount) {
+    public CursorResult(List<T> values, Cursor cursors) {
         this.values = values;
-        this.hasNext = hasNext;
-        this.cursorId = cursorId;
-        this.findCardsCount = findCardsCount;
+        this.cursors = cursors;
     }
 }

--- a/src/main/java/com/triples/project/service/CardService.java
+++ b/src/main/java/com/triples/project/service/CardService.java
@@ -2,6 +2,7 @@ package com.triples.project.service;
 
 import com.triples.project.dao.ICardDao;
 import com.triples.project.dao.collection.Card;
+import com.triples.project.dto.Cursor;
 import com.triples.project.dto.CursorResult;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -39,21 +41,85 @@ public class CardService {
     }
 
     @Transactional
-    public CursorResult<Card> findAllByOrderByIdDesc(ObjectId cursorId, Pageable page) {
-        List<Card> cards = getCards(cursorId, page);
-        ObjectId lastCursorId = cards.isEmpty() ? null :
-                                cards.get(cards.size()-1).getId();
+    public CursorResult<Card> findAllByOrderByIdDesc(String inputPrev, String inputNext, Pageable page) {
 
-        return new CursorResult<>(cards,hasNext(lastCursorId),lastCursorId, cards.size());
+        ObjectId cursorId = null;
+
+        if(inputPrev == null) {       // next cursor
+            cursorId =
+                    inputNext != null ? new ObjectId(inputNext) : null;
+
+            return nextCards(cursorId, page);
+        }
+        else {                       // prev cursor
+            cursorId = new ObjectId(inputPrev);
+
+            return prevCards(cursorId, page);
+        }
+    }
+    private CursorResult<Card> prevCards(ObjectId cursorId, Pageable page) {
+        ObjectId nextId = null, prevId = null;
+        String next = null, previous = null;
+        List<Card> cards = null;
+
+        cards = iCardDao.findByIdGreaterThanOrderByIdAsc(cursorId, page);
+        if(cards != null ) Collections.reverse(cards);
+
+        prevId = findFirstObjectId(cards);                          // Previous String cursor
+        previous = prevId != null ? prevId.toHexString() : null;   // Previous Object cursor
+
+        nextId = findLastObjectId(cards);
+        next = nextId != null ? nextId.toHexString() : null;
+
+        return new CursorResult<>(cards, Cursor.builder()
+                .hasPrevious(checkPrev(prevId))
+                .previous(previous)
+                .next(next)
+                .hasNext(checkNext(nextId))
+                .build());
     }
 
-    private List<Card> getCards(ObjectId id, Pageable page) {
-        return id == null ?
-                iCardDao.findAllByOrderByIdDesc(page) :
-                iCardDao.findByIdLessThanOrderByIdDesc(id, page);
+    private CursorResult<Card> nextCards(ObjectId cursorId, Pageable page) {
+
+        ObjectId prevId = null, nextId = null;
+        String previous = null, next = null;
+        List<Card> cards = null;
+
+        if(cursorId == null) { // first request
+            cards = iCardDao.findAllByOrderByIdDesc(page);
+        }
+        else {                 // after first request
+            cards = iCardDao.findByIdLessThanOrderByIdDesc(cursorId, page);
+        }
+
+        prevId = findFirstObjectId(cards);                        // Prev Object cursor
+        previous = prevId != null ? prevId.toHexString() : null; // Prev String cursor
+
+        nextId = findLastObjectId(cards);                      // Next Object cursor
+        next = nextId != null ? nextId.toHexString() : null;  // Next String cursor
+
+        return new CursorResult<>(cards, Cursor.builder()
+                .hasPrevious(checkPrev(prevId))
+                .previous(previous)
+                .next(next)
+                .hasNext(checkNext(nextId))
+                .build());
     }
-    private Boolean hasNext(ObjectId id) {
+
+    private Boolean checkPrev(ObjectId id) {
+        if(id == null) return false;
+        return iCardDao.existsByIdGreaterThanOrderByIdDesc(id);
+    }
+    private Boolean checkNext(ObjectId id) {
         if(id == null) return false;
         return iCardDao.existsByIdLessThanOrderByIdDesc(id);
+    }
+    private ObjectId findLastObjectId(List<Card> cards) {
+        if(cards.isEmpty()) return null;
+        else return cards.get(cards.size()-1).getId();
+    }
+    private ObjectId findFirstObjectId(List<Card> cards) {
+        if(cards.isEmpty()) return null;
+        else return cards.get(0).getId();
     }
 }

--- a/src/test/java/com/triples/project/controller/CardApiControllerTest.java
+++ b/src/test/java/com/triples/project/controller/CardApiControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -29,11 +31,14 @@ public class CardApiControllerTest {
     @Autowired private TestRestTemplate restTemplate;
 
     @Test
+    @DisplayName("커서 페이지 네이션 테스트")
     public void findAllByOrderByIdDesc() {
         // given
-        CursorResult<Card> list = cardService.findAllByOrderByIdDesc(null, PageRequest.of(0,20));
-        ObjectId id = list.getCursorId();
-        String url = "http://localhost:"+port+"/api/v1/cards?cursorId="+id+"&pageSize="+40;
+        CursorResult<Card> list = cardService.findAllByOrderByIdDesc(null,null, PageRequest.of(0,10));
+        List<Card> cards = list.getValues();
+
+        String next = cards.get(0).getId().toHexString();
+        String url = "http://localhost:"+port+"/api/v1/cards?cursorId="+next;
 
         //when
         ResponseEntity<String> responseEntity =

--- a/src/test/java/com/triples/project/service/CardServiceTest.java
+++ b/src/test/java/com/triples/project/service/CardServiceTest.java
@@ -27,18 +27,32 @@ public class CardServiceTest {
     @DisplayName("커서 페이지네이션 테스트")
     public void cursorBasedPagination() {
 
-        // first request
-        CursorResult<Card> cards = cardService.findAllByOrderByIdDesc(null, PageRequest.of(0,10));
+        // first request ( next )
+        CursorResult<Card> cards = cardService.findAllByOrderByIdDesc(null, null, PageRequest.of(0,10));
 
-        ObjectId nextCursorId = cards.getCursorId();
+        String nextCursorId = cards.getCursors().getNext();
         List<Card> list = cards.getValues();
-        assertThat(nextCursorId).isEqualTo(list.get(list.size()-1).getId());
+        String target = list.get(list.size()-1).getId().toHexString();
+        assertThat(nextCursorId).isEqualTo(target);
 
-        // after first request
-        cards = cardService.findAllByOrderByIdDesc(nextCursorId, PageRequest.of(0,10));
-        nextCursorId = cards.getCursorId();
+        // first request ( previous )
+        String prevCursorId = list.get(0).getId().toHexString();
+        cards = cardService.findAllByOrderByIdDesc(prevCursorId, null, PageRequest.of(0,10));
+        List<Card> result = cards.getValues();
+        assertThat(result.size()).isEqualTo(0);
+
+        // after first request ( next )
+        cards = cardService.findAllByOrderByIdDesc(null, nextCursorId, PageRequest.of(0,10));
+        nextCursorId = cards.getCursors().getNext();
         list = cards.getValues();
-        assertThat(nextCursorId).isEqualTo(list.get(list.size()-1).getId());
+        target = list.get(list.size()-1).getId().toHexString();
+        assertThat(nextCursorId).isEqualTo(target);
 
+        // after first request ( previous )
+        String curPrevId = list.get(0).getId().toHexString();
+        cards = cardService.findAllByOrderByIdDesc(curPrevId, null, PageRequest.of(0,10));
+        list = cards.getValues();
+        curPrevId = list.get(0).getId().toHexString();
+        assertThat(curPrevId).isEqualTo(prevCursorId);
     }
 }


### PR DESCRIPTION
스프링 커서 페이지네이션 라이브러리를 찾지 못하여
직접 구현해서 비효율적인 코드가 있을 수 있으니 수정할 부분 있으면 의견주세요!

#20 를 참고하여 
아래와 같은 구조로 클라이언트로 response 할 수 있도록 구성했습니다.
default로 20개씩 클라이언트로 전송해주며 Card list 기준으로 
첫번째 데이터와 마지막 데이터를 커서 기준으로 잡고 
이전 데이터 또는 다음 데이터를 가져올수 있도록 구현되어 있습니다.

```

{
  values: […], // cardList results
  cursors: {
    previous, // previous cursor id
    hasPrevious, // boolean
    next,  // next cursor id
    hasNext // boolean
  }
}
```

- 처음 request 

> /api/v1/cards

- 첫번째 이후 다음 데이터 request (next)

> /api/v1/cards?next={cursorId}

-  이전 데이터 reqeust ( previous )

> /api/v1/cards?previous={cursorId}

<img width="1318" alt="스크린샷 2020-09-15 오후 10 37 37" src="https://user-images.githubusercontent.com/26623547/93217496-1ce9c100-f7a4-11ea-933a-e28e9e5e2135.png">






