### PR TITLE
fix : add platform and delete duplicaton crawling card

### DIFF
--- a/src/main/java/com/triples/project/dao/ICardDao.java
+++ b/src/main/java/com/triples/project/dao/ICardDao.java
@@ -29,4 +29,6 @@ public interface ICardDao extends MongoRepository<Card, ObjectId> {
     List<Card> findByWriter(String writer);
 
     List<Card> findByCategory(String category);
+
+    List<Card> findByLink(String link);
 }

--- a/src/main/java/com/triples/project/scheduler/crawling/brunch/BrunchCrawling.java
+++ b/src/main/java/com/triples/project/scheduler/crawling/brunch/BrunchCrawling.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import com.triples.project.dao.ICardDao;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -24,12 +26,15 @@ import lombok.RequiredArgsConstructor;
  * @URL : brunch
  * @description : URL에 있는 내용을 크롤링하는 클래스
  */
+@Slf4j
 @Component("brunchCrawling")
 @RequiredArgsConstructor
 public class BrunchCrawling implements ICrawling {
 
 	// driver 재사용
-private final WebDriver driver;
+	private final WebDriver driver;
+	private final String platform = "brunch";
+	private final ICardDao iCardDao;
 
 @Override
 public List<Card> startCrawling() {
@@ -55,7 +60,7 @@ public List<Card> startCrawling() {
 		Boolean heightFlag = true;
 		//브라우져 높이
 		int browerHeight = Integer.parseInt(js.executeScript("return document.body.scrollHeight").toString());
-		System.out.println("browerHeigth : " + browerHeight);
+		log.info("browerHeigth : " + browerHeight);
 		int compareBrowerHeight = 0;
 		
 		while(heightFlag) {
@@ -68,7 +73,7 @@ public List<Card> startCrawling() {
 				e.printStackTrace();
 			}
 			compareBrowerHeight = Integer.parseInt(js.executeScript("return document.body.scrollHeight").toString());
-			System.out.println("compareBrowerHeight : " + compareBrowerHeight);
+			log.info("compareBrowerHeight : " + compareBrowerHeight);
 			if((compareBrowerHeight-browerHeight) > 0) {
 				browerHeight = compareBrowerHeight;
 			} else {
@@ -113,8 +118,12 @@ public List<Card> startCrawling() {
 			try {
 				image	   = content.findElement(By.cssSelector("div.post_thumb > img")).getAttribute("src");
 			} catch (Exception e) {
-				System.out.println("사진 없음");
+				log.info("사진 없음");
 			}
+
+			// delete duplication
+			List<Card> cards = iCardDao.findByLink(link);
+			if(cards.size() > 0) continue;
 			
 			cardList.add(
 					Card.builder()
@@ -125,6 +134,7 @@ public List<Card> startCrawling() {
 					.link(link)
 					.date(today)
 					.image(image)
+					.platform(platform)
 					.build()
 			);
 		}

--- a/src/main/java/com/triples/project/scheduler/crawling/brunch/BrunchJob.java
+++ b/src/main/java/com/triples/project/scheduler/crawling/brunch/BrunchJob.java
@@ -1,11 +1,10 @@
 package com.triples.project.scheduler.crawling.brunch;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-import org.quartz.InterruptableJob;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.UnableToInterruptJobException;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
 import com.triples.project.dao.ICardDao;
@@ -14,7 +13,7 @@ import com.triples.project.scheduler.crawling.ICrawling;
 
 import lombok.RequiredArgsConstructor;
 
-
+@Slf4j
 @RequiredArgsConstructor
 public class BrunchJob extends QuartzJobBean implements InterruptableJob {
 
@@ -22,6 +21,8 @@ public class BrunchJob extends QuartzJobBean implements InterruptableJob {
     
     private final ICrawling brunchCrawling;
 
+    private boolean isInterrupted = false;
+    private JobKey jobKey = null;
 
     // 예외 처리
     @Override
@@ -31,7 +32,11 @@ public class BrunchJob extends QuartzJobBean implements InterruptableJob {
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        // 크롤링 로직 작성 to do
+        jobKey = context.getJobDetail().getKey();
+
+        // 현재 JobName 확인
+        log.info("### {} is being executed!",
+                context.getJobDetail().getJobDataMap().get("JobName").toString());
 
         List<Card> cardList = null;
 		try {
@@ -40,7 +45,10 @@ public class BrunchJob extends QuartzJobBean implements InterruptableJob {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>" + cardList.size());
+
         cardDao.saveAll(cardList);
+
+        log.info("execute invoked, jobKey: " + jobKey + ", time:" +
+                LocalDateTime.now().toString() + ", crawling size : " + cardList.size());
     }
 }

--- a/src/main/java/com/triples/project/scheduler/crawling/festa/FestaCrawling.java
+++ b/src/main/java/com/triples/project/scheduler/crawling/festa/FestaCrawling.java
@@ -1,5 +1,6 @@
 package com.triples.project.scheduler.crawling.festa;
 
+import com.triples.project.dao.ICardDao;
 import com.triples.project.dao.collection.Card;
 import com.triples.project.scheduler.crawling.ICrawling;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class FestaCrawling implements ICrawling {
     // webDriver bean 재사용
     private final WebDriver driver;
     private final WebDriverWait webDriverWait;
+    private final ICardDao iCardDao;
 
     private final String url = "https://festa.io/events";
     private final String platform = "festa";
@@ -69,8 +71,9 @@ public class FestaCrawling implements ICrawling {
 //                    .getAttribute("textContent");
 //            // 무료, 유료 교육 , 외부 이벤트 로 수정 할 것
 
-            System.out.println(">>>>>>>>>>>>" + link);
-
+            // delete duplication
+            List<Card> cards = iCardDao.findByLink(link);
+            if(cards.size() > 0) continue;
 
             cardList.add(Card.builder().title(title).link(link).image(image)
                     .date(date).writer(writer).platform(platform).build());

--- a/src/main/java/com/triples/project/scheduler/crawling/festa/FestaJob.java
+++ b/src/main/java/com/triples/project/scheduler/crawling/festa/FestaJob.java
@@ -55,12 +55,10 @@ public class FestaJob extends QuartzJobBean implements InterruptableJob {
         cardList = festaCrawling.startCrawling();
 
         cardDao.saveAll(cardList); // to do : 중복 데이터 제거를 위한 merge 이용할 것
-
         // Crawling End
 
         log.info("execute invoked, jobKey: " + jobKey + ", time:" +
                 LocalDateTime.now().toString() + ", crawling size : " + cardList.size());
-        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>" + cardList.size());
 
     }
 }

--- a/src/main/java/com/triples/project/scheduler/crawling/velog/VelogJob.java
+++ b/src/main/java/com/triples/project/scheduler/crawling/velog/VelogJob.java
@@ -7,15 +7,13 @@ import com.triples.project.scheduler.crawling.ICrawling;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.quartz.InterruptableJob;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.UnableToInterruptJobException;
+import org.quartz.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -24,6 +22,9 @@ public class VelogJob extends QuartzJobBean implements InterruptableJob {
 
     private final ICardDao cardDao;
     private final ICrawling velogCrawling;
+
+    private boolean isInterrupted = false;
+    private JobKey jobKey = null;
 
     // 예외 처리
     @Override
@@ -34,13 +35,18 @@ public class VelogJob extends QuartzJobBean implements InterruptableJob {
     @SneakyThrows
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-        // 크롤링 로직 작성 to do
+        jobKey = context.getJobDetail().getKey();
+
+        // 현재 JobName 확인
+        log.info("### {} is being executed!",
+                context.getJobDetail().getJobDataMap().get("JobName").toString());
 
         List<Card> cardList = velogCrawling.startCrawling();
 
         cardDao.saveAll(cardList);
 
-        System.out.println("Velog >>>>>>>>>>>>>>>>>>>>>>>>>>>>" + cardList.size());
+        log.info("execute invoked, jobKey: " + jobKey + ", time:" +
+                LocalDateTime.now().toString() + ", crawling size : " + cardList.size());
 
     }
 }


### PR DESCRIPTION
- 크롤링 후 중복 제거 

크롤링 한 후 DB Insert 하기전 같은 url이 있는지 확인 후 
있다면 continue 하는 방식으로 우선 중복 제거를 했습니다. 추후 aggregation 방식 등 더 효율적인
방법이 있다면 변경하는 걸로 하면 될 것 같아요 

` List<Card> findByLink(String link);`

**현재 18시 마다 크롤링 스케줄러가 걸려있는데
헤로쿠가 sleep 모드로 변경되어 크롤링이 안되고 있습니다.
30분 이내로 Server로 reqeust 하여 sleep 모드로 변경되지 않도록 
소스 수정 가능할까요?**


